### PR TITLE
Added required include statement for constants.

### DIFF
--- a/entities/Photon.h
+++ b/entities/Photon.h
@@ -5,6 +5,8 @@
 #ifndef PHOTON_H
 #define PHOTON_H
 
+#include "../constants.h"
+
 #include <SFML/Graphics.hpp>
 using sf::Drawable;
 using sf::RenderTarget;


### PR DESCRIPTION
I tried to compile this project myself, and I received an error because it the Photon.h was unable to find PHOTON_EDGES. If this compiles for others without this, I believe it may be the compiler implicitly including this file. After including "constants.h", everything compiled just fine.